### PR TITLE
[spam]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"funding": {
 		"url": "https://github.com/sponsors/ljharb"
 	},
-	"repository": "git://github.com/inspect-js/is-object.git",
+	"repository": "git+https://github.com/inspect-js/is-object.git",
 	"main": "index",
 	"homepage": "https://github.com/inspect-js/is-object",
 	"contributors": [


### PR DESCRIPTION
The `repository` field in `package.json` currently uses an unauthenticated or SSH git URL. This requires package consumers and registry tools to have authenticated SSH GitHub access or unblocked git protocols to resolve the repository metadata.

This PR updates it to an HTTPS URL (`git+https://github.com/...`) which is publicly accessible.