### PR TITLE
[spam]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"funding": {
 		"url": "https://github.com/sponsors/ljharb"
 	},
-	"repository": "git://github.com/inspect-js/is-object.git",
+	"repository": "git+https://github.com/inspect-js/is-object.git",
 	"main": "index",
 	"homepage": "https://github.com/inspect-js/is-object",
 	"contributors": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
 	"repository": "git+https://github.com/inspect-js/is-object.git",
 	"main": "index",
 	"homepage": "https://github.com/inspect-js/is-object",
+	"engines": {
+		"node": ">= 0.4"
+	},
 	"contributors": [
 		{
 			"name": "Raynos"


### PR DESCRIPTION
Updates the published repository metadata from the legacy `git://` protocol to `git+https://`, so package tooling can resolve the GitHub repository without SSH or blocked git protocol access.

Validation:
- `node -e "const p=require('./package.json'); if (p.repository !== 'git+https://github.com/inspect-js/is-object.git') process.exit(1); console.log(p.repository)"`
- `git ls-remote https://github.com/inspect-js/is-object.git HEAD`
- `npm test`